### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -749,6 +749,7 @@ padding-left: 10px;
 #rightsidebar h2 a {
 display:block;
 padding-left:.6em;
+color: white;
 }
 
 #rightsidebar h2.sez_utenti {


### PR DESCRIPTION
Va modificato il colore del testo nel file style.css alla voce #rightsidebar h2 a
color: white;
quando un link si trova nel titolo di un menu o widget nella barra dx altrimenti mostra lo stesso colore dello sfondo e quindi non è visibile.

e.g. Nella modifica che ho fatto all'elenco delle sotto-pagine il titolo ha un link per risalire di un livello il grado di annidamento, ma, appunto non è visibile.