### PR TITLE
Update widget.php

### DIFF
--- a/include/widget.php
+++ b/include/widget.php
@@ -636,5 +636,41 @@
 
 <?php
         }
-    }    
+    } 
+    
+//**************************************************************************************************************
+// Widget che mostra l'immagine in evidenza associata a una pagina o a un post
+//**************************************************************************************************************
+class ThumbWidget extends WP_Widget {
+    function ThumbWidget() {
+        parent::__construct( false, 'Immagine in evidenza' );
+    }
+    function widget( $args, $instance ) {
+        extract($args);
+        echo $before_widget;
+        
+        if ( has_post_thumbnail() ) {
+	         
+           the_post_thumbnail('rightbar-thumb');
+           
+        } 
+ 
+        echo $after_widget;
+    }
+    function update( $new_instance, $old_instance ) {
+        return $new_instance;
+    }
+    function form( $instance ) {
+    }
+}
+ 
+function register_ThumbWidget() {
+    register_widget( 'ThumbWidget' );
+  if ( function_exists( 'add_image_size' ) ) { 
+	add_image_size( 'rightbar-thumb', 180, 9999 );  
+}
+}
+ 
+add_action( 'widgets_init', 'register_ThumbWidget' );    
+
 ?>

--- a/style.css
+++ b/style.css
@@ -1620,3 +1620,17 @@ p.pasw2015cookies-banner-text {
 .short_dest_col_testo_3C {margin-left:100px; padding-top:5px;margin-right:120px;margin-top:0px;padding-bottom:5px;}
 .short_dest_col_testo_2C {padding-top:5px;margin-right:120px;margin-top:0px;padding-bottom:5px;}
 .short_dest_col_date {width:120px;float:right; text-align:right;padding-top:5px;}
+
+/* Formattazione dell'immagine in evidenza sulla barra destra */
+.attachment-rightbar-thumb{
+  width: 100%!important;
+  height: 100%!important;
+  
+  border: 1px #aaaacc solid;
+  background-color: white;
+  padding: 1px;
+  border-radius: 5px;
+  -webkit-box-shadow: 3px 3px 4px rgba(127, 126, 127, 0.50);
+  -moz-box-shadow:    3px 3px 4px rgba(127, 126, 127, 0.50);
+  box-shadow:         3px 3px 4px rgba(127, 126, 127, 0.50); 	
+}


### PR DESCRIPTION
Il Widget aggiunto a questo file è lo stesso che avevo impropriamente suggerito nel file functions.php e che permette di visualizzare l'immagine in evidenza associata ad un post o a una pagina. Esso crea anche una miniatura proporzionale adatta ad essere visualizzata sulla barra destra. in coda al file style.css va aggiunta la formattazione di questa immagine sulla class ".attachment-rightbar-thumb" assegnata da wordpress.
Ragionevolmente, se lo si vuole lasciare, l'ho spostato in questo file.