### PR TITLE
Update widget.php

### DIFF
--- a/include/widget.php
+++ b/include/widget.php
@@ -533,7 +533,8 @@
               	$term_id = $taxdestinatari;
               	$term = get_term( $term_id, $taxonomy );
               	$term_link = get_term_link( $term );
-            	$after_title = '<span class="showall_widget after_widget_title"><a href='. esc_url( $term_link ) .' title="Tutti gli articoli di '. $term->name . '" >Mostra Tutto &rsaquo;</a></span>'.$after_title;
+              	$link = esc_url( $term_link ).'&post_type=post';
+            	$after_title = '<span class="showall_widget after_widget_title"><a href='. $link .' title="Tutti gli articoli di '. $term->name . '" >Mostra Tutto &rsaquo;</a></span>'.$after_title;
     		}            
 
             if ( $title ) {


### PR DESCRIPTION
Aggiornato widget destinatari
Dopo l'aggiornamento a wp 4.2 se si preme sul link mostra tutto vengono visualizzati sia articoli che pagine.
Con questa modifica si visualizzano nuovamente solo gli articoli