### PR TITLE
Patch 24

### DIFF
--- a/page.php
+++ b/page.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 <?php get_sidebar(); ?>
-
+<?php global $children; ?>
 <?php if (have_posts()){
         while (have_posts()) : the_post();
 ?>            <div class="post" id="post-<?php the_ID(); ?>">

--- a/sidebar-right.php
+++ b/sidebar-right.php
@@ -1,6 +1,7 @@
 <div id="rightsidebar" class="column">
 <ul>
 <?php
+global $children;
 if ($children && get_option( 'pasw_submenu') == '4') { ?>
 	<li class="widget widget_nav_menu">
 		<h2 class="widgettitle"><?php echo $post->post_title; ?></h2>


### PR DESCRIPTION
Creata variabile globale $Children
Dopo l'implementazione della funzione get_sidebar('right') non veniva più alimentata la variabile children nella sidebar e quindi nel caso di opzione sub-menu = on sidebar questa non apportava alcuna visualizzazione.